### PR TITLE
Require charge to replace more than one node

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,3 @@
 default?
 dye?
+technic


### PR DESCRIPTION
This makes the replacer a technic power tool and allows using the modes that replace more than one node at a time without creative, but using charge to do so.