### PR TITLE
Do limited search if too many positions are found

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -108,6 +108,8 @@ replacer.has_unifieddyes_mod = minetest.get_modpath('unifieddyes')
 dofile(path .. "/utils.lua")
 -- unifiedddyes support functions
 dofile(path .. "/unifieddyes.lua")
+
+replacer.datastructures = dofile(path .. "/datastructures.lua")
 -- adds a tool for inspecting nodes and entities
 dofile(path .. "/inspect.lua")
 dofile(path .. "/replacer_blabla.lua")

--- a/init.lua
+++ b/init.lua
@@ -74,7 +74,7 @@ replacer.blacklist["protector:protect2"] = true
 replacer.max_charge = 30000
 replacer.charge_per_node = 15
 -- node count limit
-replacer.max_nodes = tonumber(minetest.settings:get("replacer.max_nodes") or 3168)
+replacer.max_nodes = tonumber(minetest.settings:get("replacer.max_nodes") or 716)
 -- Time limit when placing the nodes, in seconds
 replacer.max_time = tonumber(minetest.settings:get("replacer.max_time") or 1.0)
 

--- a/replacer.lua
+++ b/replacer.lua
@@ -326,59 +326,72 @@ function replacer.replace(itemstack, user, pt, right_clicked)
 	end
 
 	local ps, num
-	if r.modes[2] == mode then
-		-- field
-		-- get connected positions for plane field replacing
-		local pdif = vector.subtract(pt.above, pt.under)
-		local adps, n = {}, 1
+	if mode == "field" then
+		-- Get four walk directions which are orthogonal to the field
+		local normal = vector.subtract(pt.above, pt.under)
+		local dirs, n = {}, 1
 		local p
-		for _, i in pairs{ "x", "y", "z" } do
-			if 0 == pdif[i] then
+		for coord in pairs(normal) do
+			if normal[coord] == 0 then
 				for a = -1, 1, 2 do
-					p = { x = 0, y = 0, z = 0 }
-					p[i] = a
-					adps[n] = p
+					p = {x = 0, y = 0, z = 0}
+					p[coord] = a
+					dirs[n] = p
 					n = n + 1
 				end
 			end
 		end
+		-- The normal is used as offset to test if the searched position
+		-- is next to the field; the offset goes in the other direction when
+		-- a right click happens
 		if right_clicked then
-			pdif = vector.multiply(pdif, -1)
+			normal = vector.multiply(normal, -1)
 		end
+		-- Search along the plane next to the field
 		right_clicked = (right_clicked and true) or false
-		ps, num = rp.get_ps(pos, { func = rp.field_position, name = node_toreplace.name,
-			pname = name, above = pdif, right_clicked = right_clicked }, adps, max_nodes)
-	elseif r.modes[3] == mode then
-		-- crust
+		ps, num = rp.search_positions({
+			startpos = pos,
+			fdata = {func = rp.field_position, name = node_toreplace.name,
+				pname = name, above = normal, right_clicked = right_clicked},
+			moves = dirs,
+			max_positions = max_nodes
+		})
+	elseif mode == "crust" then
+		-- Search positions of air (or similar) nodes next to the crust
 		local nodename_clicked = rp.get_node(pt.under).name
-		local aps, n, aboves = rp.get_ps(pt.above, { func = rp.crust_above_position,
-			name = nodename_clicked, pname = name }, nil, max_nodes)
-		if aps then
-			if right_clicked then
-				local data = { ps = aps, num = n, name = nodename_clicked, pname = name }
-				rp.reduce_crust_above_ps(data)
-				ps, num = data.ps, data.num
-			else
-				ps, num = rp.get_ps(pt.under, { func = rp.crust_under_position,
-					name = node_toreplace.name, pname = name, aboves = aboves },
-					rp.offsets_hollowcube, max_nodes)
-				if ps then
-					local data = { aboves = aboves, ps = ps, num = num }
-					rp.reduce_crust_ps(data)
-					ps, num = data.ps, data.num
-				end
-			end
+		local aps, n, aboves = rp.search_positions({
+			startpos = pt.above,
+			fdata = {func = rp.crust_above_position, name = nodename_clicked,
+				pname = name},
+			moves = rp.offsets_touch,
+			max_positions = max_nodes
+		})
+		if right_clicked then
+			-- Remove positions which are not directly touching the crust
+			local data = {ps = aps, num = n, name = nodename_clicked,
+				pname = name}
+			rp.reduce_crust_above_ps(data)
+			ps, num = data.ps, data.num
+		else
+			-- Search crust positions which are next to the previously found
+			-- air (or similar) node positions
+			ps, num = rp.search_positions({
+				startpos = pt.under,
+				fdata = {func = rp.crust_under_position,
+					name = node_toreplace.name, pname = name,
+					aboves = aboves},
+				moves = rp.offsets_hollowcube,
+				max_positions = max_nodes
+			})
+			-- Keep only positions which are directly touching those previously
+			-- found positions
+			local data = {aboves = aboves, ps = ps, num = num}
+			rp.reduce_crust_ps(data)
+			ps, num = data.ps, data.num
 		end
 	end
 
-	-- reset known nodes table
-	replacer.patterns.known_nodes = {}
-
-	if not ps then
-		-- TODO: does this ever happen anymore?
-		r.inform(name, rb.too_many_nodes_detected)
-		return
-	end
+	replacer.patterns.reset_nodes_cache()
 
 	if 0 == num then
 		local succ, err = r.replace_single_node(pos, node_toreplace, nnd, user,
@@ -398,7 +411,6 @@ function replacer.replace(itemstack, user, pt, right_clicked)
 
 	-- set nodes
 	local t_start = minetest.get_us_time()
-	-- TODO
 	local max_time_us = 1000000 * replacer.max_time
 	-- Turn ps into a binary heap
 	replacer.datastructures.create_binary_heap({

--- a/replacer.lua
+++ b/replacer.lua
@@ -354,7 +354,8 @@ function replacer.replace(itemstack, user, pt, right_clicked)
 			fdata = {func = rp.field_position, name = node_toreplace.name,
 				pname = name, above = normal, right_clicked = right_clicked},
 			moves = dirs,
-			max_positions = max_nodes
+			max_positions = max_nodes,
+			radius_exceeded = 4,
 		})
 	elseif mode == "crust" then
 		-- Search positions of air (or similar) nodes next to the crust
@@ -364,7 +365,8 @@ function replacer.replace(itemstack, user, pt, right_clicked)
 			fdata = {func = rp.crust_above_position, name = nodename_clicked,
 				pname = name},
 			moves = rp.offsets_touch,
-			max_positions = max_nodes
+			max_positions = max_nodes,
+			radius_exceeded = 4,
 		})
 		if right_clicked then
 			-- Remove positions which are not directly touching the crust
@@ -429,6 +431,11 @@ function replacer.replace(itemstack, user, pt, right_clicked)
 	local num_nodes = 0
 	while not ps:is_empty() do
 		num_nodes = num_nodes+1
+		if num_nodes > max_nodes then
+			-- This can happen if too many nodes were detected and the nodes
+			-- limit has been set to a small value
+			break
+		end
 		-- Take the position nearest to the start position
 		local pos = ps:take()
 		local succ, err = r.replace_single_node(pos, minetest.get_node(pos), nnd,

--- a/replacer.lua
+++ b/replacer.lua
@@ -27,9 +27,6 @@ replacer.mode_colours[r.modes[1]] = "#ffffff"
 replacer.mode_colours[r.modes[2]] = "#54FFAC"
 replacer.mode_colours[r.modes[3]] = "#9F6200"
 
-local path = minetest.get_modpath("replacer")
-local datastructures = dofile(path .. "/datastructures.lua")
-
 local is_int = function(value)
 	return type(value) == 'number' and math.floor(value) == value
 end
@@ -404,7 +401,7 @@ function replacer.replace(itemstack, user, pt, right_clicked)
 	-- TODO
 	local max_time_us = 1000000 * replacer.max_time
 	-- Turn ps into a binary heap
-	datastructures.create_binary_heap({
+	replacer.datastructures.create_binary_heap({
 		input = ps,
 		n = num,
 		compare = function(pos1, pos2)

--- a/replacer_blabla.lua
+++ b/replacer_blabla.lua
@@ -15,7 +15,6 @@ replacer.blabla.not_a_node = 'Error: "%s" is not a node.'
 replacer.blabla.wait_for_load = "Target node not yet loaded. Please wait a moment for the server to catch up."
 replacer.blabla.nothing_to_replace = "Nothing to replace."
 replacer.blabla.need_more_charge = "Not enough charge to use this mode."
-replacer.blabla.too_many_nodes_detected = "Aborted, too many nodes detected."
 replacer.blabla.charge_required = "Need %d charge to replace %d nodes."
 replacer.blabla.count_replaced = "%s nodes replaced."
 replacer.blabla.mode_changed = "Mode changed to %s: %s"

--- a/replacer_patterns.lua
+++ b/replacer_patterns.lua
@@ -15,6 +15,11 @@ function replacer.patterns.get_node(pos)
 	return node
 end
 
+-- The cache is only valid as long as no node is changed in the world.
+function replacer.patterns.reset_nodes_cache()
+	replacer.patterns.known_nodes = {}
+end
+
 -- tests if there's a node at pos which should be replaced
 function replacer.patterns.replaceable(pos, name, pname)
 	return (rp.get_node(pos).name == name) and (not minetest.is_protected(pos, pname))
@@ -139,18 +144,6 @@ function replacer.patterns.reduce_crust_above_ps(data)
 	data.num = n
 end
 
-function replacer.patterns.mantle_position(pos, data)
-	if not rp.replaceable(pos, data.name, data.pname) then
-		return false
-	end
-	for i = 1, 6 do
-		if rp.get_node(vector.add(pos, rp.offsets_touch[i])).name ~= data.name then
-			return true
-		end
-	end
-	return false
-end
-
 
 -- Algorithm created by sofar and changed by others:
 -- https://github.com/minetest/minetest/commit/d7908ee49480caaab63d05c8a53d93103579d7a9
@@ -206,9 +199,10 @@ local function search_dfs(go, p, apply_move, moves)
 end
 
 
-function replacer.patterns.get_ps(pos, fdata, moves, max_positions)
-	moves = moves or rp.offsets_touch
-	max_positions = max_positions or math.huge
+function replacer.patterns.search_positions(params)
+	moves = params.moves
+	max_positions = params.max_positions
+	local fdata = params.fdata
 	-- visiteds has only positions where fdata.func evaluated to true
 	local visiteds = {}
 	local founds = {}
@@ -227,6 +221,6 @@ function replacer.patterns.get_ps(pos, fdata, moves, max_positions)
 		end
 		return true
 	end
-	search_dfs(go, pos, vector.add, moves)
+	search_dfs(go, params.startpos, vector.add, moves)
 	return founds, n_founds, visiteds
 end


### PR DESCRIPTION
I have replaced the search algorithm with the one used in minetest for falling nodes. (I did not implement an probably even more efficient scanline floodfill algorithm)
After that I've changed/removed outdated code.
The third commit implements the special limited search behaviour: If the nodes limit is exceeded, it searches again but only at positions within a sphere around the starting position.
For the player this means that he/she can use the tool multiple times to e.g. place many nodes onto a wall. I reduced the maximum number of nodes to search for performance reasons.
