### PR TITLE
Reduce Technic registration warnings

### DIFF
--- a/replacer/replacer.lua
+++ b/replacer/replacer.lua
@@ -700,11 +700,19 @@ if r.has_technic_mod then
 	function replacer.tool_def_technic()
 		local def = r.tool_def_basic()
 		def.description = rb.description_technic
-		def.wear_represents = 'technic_RE_charge'
-		def.on_refill = technic.refill_RE_charge
+		if technic.plus then
+			def.technic_max_charge = r.max_charge
+		else
+			def.wear_represents = 'technic_RE_charge'
+			def.on_refill = technic.refill_RE_charge
+		end
 		return def
 	end
-	technic.register_power_tool(r.tool_name_technic, r.max_charge)
-	minetest.register_tool(r.tool_name_technic, r.tool_def_technic())
+	if technic.plus then
+		technic.register_power_tool(r.tool_name_technic, r.tool_def_technic())
+	else
+		technic.register_power_tool(r.tool_name_technic, r.max_charge)
+		minetest.register_tool(r.tool_name_technic, r.tool_def_technic())
+	end
 end
 


### PR DESCRIPTION
This just reduces registration warnings by not running through compatibility extensions.

```log
2022-06-32 14:22:10: WARNING[Main]: Deprecated technic.register_power_tool use. Setting max_charge for replacer:replacer_technic
[replacer] loaded

.... other stuff removed ....

2022-06-32 14:22:12: WARNING[Main]: Deprecated technic.register_power_tool use. Ensuring fields for replacer:replacer_technic
2022-06-32 14:22:12: WARNING[Main]: Mod replacer seems to be aware of technic.plus but replacer:replacer_technic is still using deprecated registration, skipping charge compatibility.
2022-06-32 14:22:12: WARNING[Main]: Updated on_refill and max_charge for replacer:replacer_technic
```

I would also recommend moving to new itemdef.technic_get_charge / itemdef.technic_set_charge described here https://github.com/minetest-mods/technic/pull/600